### PR TITLE
feat: Create ViewToggle component for grid/list view switching

### DIFF
--- a/components/view-toggle.test.tsx
+++ b/components/view-toggle.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ViewToggle, ViewMode } from "./view-toggle";
+
+describe("ViewToggle", () => {
+  const mockOnViewModeChange = jest.fn();
+
+  beforeEach(() => {
+    mockOnViewModeChange.mockClear();
+  });
+
+  it("renders both grid and list buttons", () => {
+    render(
+      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    expect(screen.getByLabelText("Switch to grid view")).toBeInTheDocument();
+    expect(screen.getByLabelText("Switch to list view")).toBeInTheDocument();
+  });
+
+  it("shows grid button as active when viewMode is grid", () => {
+    render(
+      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    const gridButton = screen.getByLabelText("Switch to grid view");
+    expect(gridButton).toHaveAttribute("aria-pressed", "true");
+    expect(gridButton).toHaveClass("bg-primary");
+  });
+
+  it("shows list button as active when viewMode is list", () => {
+    render(
+      <ViewToggle viewMode="list" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    const listButton = screen.getByLabelText("Switch to list view");
+    expect(listButton).toHaveAttribute("aria-pressed", "true");
+    expect(listButton).toHaveClass("bg-primary");
+  });
+
+  it("calls onViewModeChange with 'grid' when grid button is clicked", () => {
+    render(
+      <ViewToggle viewMode="list" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    const gridButton = screen.getByLabelText("Switch to grid view");
+    fireEvent.click(gridButton);
+
+    expect(mockOnViewModeChange).toHaveBeenCalledWith("grid");
+  });
+
+  it("calls onViewModeChange with 'list' when list button is clicked", () => {
+    render(
+      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    const listButton = screen.getByLabelText("Switch to list view");
+    fireEvent.click(listButton);
+
+    expect(mockOnViewModeChange).toHaveBeenCalledWith("list");
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <ViewToggle
+        viewMode="grid"
+        onViewModeChange={mockOnViewModeChange}
+        className="custom-class"
+      />
+    );
+
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+
+  it("has proper accessibility attributes", () => {
+    render(
+      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    const gridButton = screen.getByLabelText("Switch to grid view");
+    const listButton = screen.getByLabelText("Switch to list view");
+
+    expect(gridButton).toHaveAttribute("aria-label", "Switch to grid view");
+    expect(gridButton).toHaveAttribute("aria-pressed", "true");
+    expect(listButton).toHaveAttribute("aria-label", "Switch to list view");
+    expect(listButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("includes screen reader text for buttons", () => {
+    render(
+      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    expect(screen.getByText("Grid view")).toBeInTheDocument();
+    expect(screen.getByText("List view")).toBeInTheDocument();
+  });
+});

--- a/components/view-toggle.tsx
+++ b/components/view-toggle.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Grid3X3, List } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type ViewMode = "grid" | "list";
+
+interface ViewToggleProps {
+  viewMode: ViewMode;
+  onViewModeChange: (viewMode: ViewMode) => void;
+  className?: string;
+}
+
+export function ViewToggle({ viewMode, onViewModeChange, className }: ViewToggleProps) {
+  return (
+    <div className={cn("flex items-center gap-1 p-1 bg-muted rounded-lg", className)}>
+      <Button
+        variant={viewMode === "grid" ? "default" : "ghost"}
+        size="sm"
+        onClick={() => onViewModeChange("grid")}
+        className={cn(
+          "h-8 px-3 transition-all duration-200",
+          viewMode === "grid"
+            ? "bg-primary text-primary-foreground shadow-sm"
+            : "hover:bg-accent hover:text-accent-foreground"
+        )}
+        aria-label="Switch to grid view"
+        aria-pressed={viewMode === "grid"}
+      >
+        <Grid3X3 className="h-4 w-4" />
+        <span className="sr-only">Grid view</span>
+      </Button>
+      <Button
+        variant={viewMode === "list" ? "default" : "ghost"}
+        size="sm"
+        onClick={() => onViewModeChange("list")}
+        className={cn(
+          "h-8 px-3 transition-all duration-200",
+          viewMode === "list"
+            ? "bg-primary text-primary-foreground shadow-sm"
+            : "hover:bg-accent hover:text-accent-foreground"
+        )}
+        aria-label="Switch to list view"
+        aria-pressed={viewMode === "list"}
+      >
+        <List className="h-4 w-4" />
+        <span className="sr-only">List view</span>
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Overview
This PR implements the ViewToggle component as specified in issue #1, allowing users to switch between grid and list views for the recipe list.

## Changes Made
- ✅ Created `ViewToggle` component with grid and list button options
- ✅ Added proper icons (Grid3X3 and List from lucide-react)
- ✅ Implemented active state styling for selected view
- ✅ Added hover effects and smooth transitions
- ✅ Added proper ARIA labels and keyboard navigation support
- ✅ Created comprehensive unit tests for ViewToggle component

## Technical Details
- Component accepts `viewMode` and `onViewModeChange` props
- Uses lucide-react icons for grid and list views
- Implements proper accessibility with ARIA labels and screen reader support
- Follows existing UI component patterns in the codebase
- Includes smooth transitions and hover effects

## Testing
- All unit tests pass
- Component follows accessibility best practices
- No linting errors

## Related
Resolves #1

## Files Added
- `components/view-toggle.tsx` - Main component
- `components/view-toggle.test.tsx` - Unit tests