### PR TITLE
CC Demo: Create View Toggle Component

### DIFF
--- a/components/view-toggle.test.tsx
+++ b/components/view-toggle.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ViewToggle, ViewMode } from "./view-toggle";
+
+describe("ViewToggle", () => {
+  const mockOnViewModeChange = jest.fn();
+
+  beforeEach(() => {
+    mockOnViewModeChange.mockClear();
+  });
+
+  it("renders both grid and list buttons", () => {
+    render(
+      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    expect(screen.getByLabelText("Switch to grid view")).toBeInTheDocument();
+    expect(screen.getByLabelText("Switch to list view")).toBeInTheDocument();
+  });
+
+  it("shows grid button as active when viewMode is grid", () => {
+    render(
+      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    const gridButton = screen.getByLabelText("Switch to grid view");
+    expect(gridButton).toHaveAttribute("aria-pressed", "true");
+    expect(gridButton).toHaveClass("bg-primary");
+  });
+
+  it("shows list button as active when viewMode is list", () => {
+    render(
+      <ViewToggle viewMode="list" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    const listButton = screen.getByLabelText("Switch to list view");
+    expect(listButton).toHaveAttribute("aria-pressed", "true");
+    expect(listButton).toHaveClass("bg-primary");
+  });
+
+  it("calls onViewModeChange with 'grid' when grid button is clicked", () => {
+    render(
+      <ViewToggle viewMode="list" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    const gridButton = screen.getByLabelText("Switch to grid view");
+    fireEvent.click(gridButton);
+
+    expect(mockOnViewModeChange).toHaveBeenCalledWith("grid");
+  });
+
+  it("calls onViewModeChange with 'list' when list button is clicked", () => {
+    render(
+      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    const listButton = screen.getByLabelText("Switch to list view");
+    fireEvent.click(listButton);
+
+    expect(mockOnViewModeChange).toHaveBeenCalledWith("list");
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <ViewToggle
+        viewMode="grid"
+        onViewModeChange={mockOnViewModeChange}
+        className="custom-class"
+      />
+    );
+
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+
+  it("has proper accessibility attributes", () => {
+    render(
+      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    const gridButton = screen.getByLabelText("Switch to grid view");
+    const listButton = screen.getByLabelText("Switch to list view");
+
+    expect(gridButton).toHaveAttribute("aria-label", "Switch to grid view");
+    expect(gridButton).toHaveAttribute("aria-pressed", "true");
+    expect(listButton).toHaveAttribute("aria-label", "Switch to list view");
+    expect(listButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("includes screen reader text for buttons", () => {
+    render(
+      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
+    );
+
+    expect(screen.getByText("Grid view")).toBeInTheDocument();
+    expect(screen.getByText("List view")).toBeInTheDocument();
+  });
+});

--- a/components/view-toggle.test.tsx
+++ b/components/view-toggle.test.tsx
@@ -2,94 +2,78 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { ViewToggle, ViewMode } from "./view-toggle";
 
 describe("ViewToggle", () => {
-  const mockOnViewModeChange = jest.fn();
+  const mockOnViewChange = jest.fn();
 
   beforeEach(() => {
-    mockOnViewModeChange.mockClear();
+    mockOnViewChange.mockClear();
   });
 
   it("renders both grid and list buttons", () => {
-    render(
-      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
-    );
-
+    render(<ViewToggle currentView="grid" onViewChange={mockOnViewChange} />);
+    
     expect(screen.getByLabelText("Switch to grid view")).toBeInTheDocument();
     expect(screen.getByLabelText("Switch to list view")).toBeInTheDocument();
   });
 
-  it("shows grid button as active when viewMode is grid", () => {
-    render(
-      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
-    );
-
+  it("shows grid button as active when currentView is grid", () => {
+    render(<ViewToggle currentView="grid" onViewChange={mockOnViewChange} />);
+    
     const gridButton = screen.getByLabelText("Switch to grid view");
     expect(gridButton).toHaveAttribute("aria-pressed", "true");
     expect(gridButton).toHaveClass("bg-primary");
   });
 
-  it("shows list button as active when viewMode is list", () => {
-    render(
-      <ViewToggle viewMode="list" onViewModeChange={mockOnViewModeChange} />
-    );
-
+  it("shows list button as active when currentView is list", () => {
+    render(<ViewToggle currentView="list" onViewChange={mockOnViewChange} />);
+    
     const listButton = screen.getByLabelText("Switch to list view");
     expect(listButton).toHaveAttribute("aria-pressed", "true");
     expect(listButton).toHaveClass("bg-primary");
   });
 
-  it("calls onViewModeChange with 'grid' when grid button is clicked", () => {
-    render(
-      <ViewToggle viewMode="list" onViewModeChange={mockOnViewModeChange} />
-    );
-
-    const gridButton = screen.getByLabelText("Switch to grid view");
-    fireEvent.click(gridButton);
-
-    expect(mockOnViewModeChange).toHaveBeenCalledWith("grid");
-  });
-
-  it("calls onViewModeChange with 'list' when list button is clicked", () => {
-    render(
-      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
-    );
-
+  it("calls onViewChange with 'list' when list button is clicked", () => {
+    render(<ViewToggle currentView="grid" onViewChange={mockOnViewChange} />);
+    
     const listButton = screen.getByLabelText("Switch to list view");
     fireEvent.click(listButton);
+    
+    expect(mockOnViewChange).toHaveBeenCalledWith("list");
+  });
 
-    expect(mockOnViewModeChange).toHaveBeenCalledWith("list");
+  it("calls onViewChange with 'grid' when grid button is clicked", () => {
+    render(<ViewToggle currentView="list" onViewChange={mockOnViewChange} />);
+    
+    const gridButton = screen.getByLabelText("Switch to grid view");
+    fireEvent.click(gridButton);
+    
+    expect(mockOnViewChange).toHaveBeenCalledWith("grid");
   });
 
   it("applies custom className", () => {
     const { container } = render(
-      <ViewToggle
-        viewMode="grid"
-        onViewModeChange={mockOnViewModeChange}
+      <ViewToggle 
+        currentView="grid" 
+        onViewChange={mockOnViewChange} 
         className="custom-class"
       />
     );
-
+    
     expect(container.firstChild).toHaveClass("custom-class");
   });
 
   it("has proper accessibility attributes", () => {
-    render(
-      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
-    );
-
+    render(<ViewToggle currentView="grid" onViewChange={mockOnViewChange} />);
+    
     const gridButton = screen.getByLabelText("Switch to grid view");
     const listButton = screen.getByLabelText("Switch to list view");
-
-    expect(gridButton).toHaveAttribute("aria-label", "Switch to grid view");
+    
     expect(gridButton).toHaveAttribute("aria-pressed", "true");
-    expect(listButton).toHaveAttribute("aria-label", "Switch to list view");
     expect(listButton).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("includes screen reader text for buttons", () => {
-    render(
-      <ViewToggle viewMode="grid" onViewModeChange={mockOnViewModeChange} />
-    );
-
+  it("includes screen reader text for icons", () => {
+    render(<ViewToggle currentView="grid" onViewChange={mockOnViewChange} />);
+    
     expect(screen.getByText("Grid view")).toBeInTheDocument();
     expect(screen.getByText("List view")).toBeInTheDocument();
   });

--- a/components/view-toggle.tsx
+++ b/components/view-toggle.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Grid3X3, List } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type ViewMode = "grid" | "list";
+
+interface ViewToggleProps {
+  viewMode: ViewMode;
+  onViewModeChange: (viewMode: ViewMode) => void;
+  className?: string;
+}
+
+export function ViewToggle({ viewMode, onViewModeChange, className }: ViewToggleProps) {
+  return (
+    <div className={cn("flex items-center gap-1 p-1 bg-muted rounded-lg", className)}>
+      <Button
+        variant={viewMode === "grid" ? "default" : "ghost"}
+        size="sm"
+        onClick={() => onViewModeChange("grid")}
+        className={cn(
+          "h-8 px-3 transition-all duration-200",
+          viewMode === "grid"
+            ? "bg-primary text-primary-foreground shadow-sm"
+            : "hover:bg-accent hover:text-accent-foreground"
+        )}
+        aria-label="Switch to grid view"
+        aria-pressed={viewMode === "grid"}
+      >
+        <Grid3X3 className="h-4 w-4" />
+        <span className="sr-only">Grid view</span>
+      </Button>
+      <Button
+        variant={viewMode === "list" ? "default" : "ghost"}
+        size="sm"
+        onClick={() => onViewModeChange("list")}
+        className={cn(
+          "h-8 px-3 transition-all duration-200",
+          viewMode === "list"
+            ? "bg-primary text-primary-foreground shadow-sm"
+            : "hover:bg-accent hover:text-accent-foreground"
+        )}
+        aria-label="Switch to list view"
+        aria-pressed={viewMode === "list"}
+      >
+        <List className="h-4 w-4" />
+        <span className="sr-only">List view</span>
+      </Button>
+    </div>
+  );
+}

--- a/components/view-toggle.tsx
+++ b/components/view-toggle.tsx
@@ -7,42 +7,43 @@ import { cn } from "@/lib/utils";
 export type ViewMode = "grid" | "list";
 
 interface ViewToggleProps {
-  viewMode: ViewMode;
-  onViewModeChange: (viewMode: ViewMode) => void;
+  currentView: ViewMode;
+  onViewChange: (view: ViewMode) => void;
   className?: string;
 }
 
-export function ViewToggle({ viewMode, onViewModeChange, className }: ViewToggleProps) {
+export function ViewToggle({ currentView, onViewChange, className }: ViewToggleProps) {
   return (
     <div className={cn("flex items-center gap-1 p-1 bg-muted rounded-lg", className)}>
       <Button
-        variant={viewMode === "grid" ? "default" : "ghost"}
+        variant={currentView === "grid" ? "default" : "ghost"}
         size="sm"
-        onClick={() => onViewModeChange("grid")}
+        onClick={() => onViewChange("grid")}
         className={cn(
           "h-8 px-3 transition-all duration-200",
-          viewMode === "grid"
+          currentView === "grid"
             ? "bg-primary text-primary-foreground shadow-sm"
-            : "hover:bg-accent hover:text-accent-foreground"
+            : "hover:bg-background hover:text-foreground"
         )}
         aria-label="Switch to grid view"
-        aria-pressed={viewMode === "grid"}
+        aria-pressed={currentView === "grid"}
       >
         <Grid3X3 className="h-4 w-4" />
         <span className="sr-only">Grid view</span>
       </Button>
+      
       <Button
-        variant={viewMode === "list" ? "default" : "ghost"}
+        variant={currentView === "list" ? "default" : "ghost"}
         size="sm"
-        onClick={() => onViewModeChange("list")}
+        onClick={() => onViewChange("list")}
         className={cn(
           "h-8 px-3 transition-all duration-200",
-          viewMode === "list"
+          currentView === "list"
             ? "bg-primary text-primary-foreground shadow-sm"
-            : "hover:bg-accent hover:text-accent-foreground"
+            : "hover:bg-background hover:text-foreground"
         )}
         aria-label="Switch to list view"
-        aria-pressed={viewMode === "list"}
+        aria-pressed={currentView === "list"}
       >
         <List className="h-4 w-4" />
         <span className="sr-only">List view</span>


### PR DESCRIPTION
## Overview
This PR implements the ViewToggle component as specified in issue #8, creating a reusable component that allows users to switch between grid and list view for recipe browsing.

## Changes Made
- ✅ **1.1** Created `components/view-toggle.tsx` with grid and list icons from lucide-react
- ✅ **1.2** Implemented toggle button with proper styling and hover states
- ✅ **1.3** Added accessibility attributes (ARIA labels, keyboard navigation)
- ✅ **1.4** Created TypeScript interface for ViewToggle props
- ✅ **1.5** Added comprehensive unit tests for ViewToggle component

## Features
- **ViewMode Type**: Exported `ViewMode` type for type safety
- **Accessibility**: Full ARIA support with proper labels and pressed states
- **Responsive Design**: Mobile-friendly touch targets and styling
- **Visual Feedback**: Clear active/inactive states with smooth transitions
- **Keyboard Navigation**: Full keyboard support for accessibility
- **Screen Reader Support**: Hidden text for screen readers

## Technical Details
- Uses existing Button component from UI library
- Follows existing design system patterns with Tailwind CSS
- Implements proper TypeScript interfaces
- Includes comprehensive test coverage
- Uses lucide-react icons (Grid3X3, List)

## Testing
- Unit tests cover all functionality including:
  - Button rendering and state management
  - Click handlers and view changes
  - Accessibility attributes
  - Custom className support
  - Screen reader text

## Resolves
Closes #8